### PR TITLE
Updating the quay.io/cloudservices/ repo to celery-exporter-container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # celery-exporter-container
-Repository to help build a celery-exporter docker image for use with cloudigrade.
+Repository to help build a celery-exporter-container docker image for use with cloudigrade.
 
 ## Building
 
 ```
-$ docker build . -tag quay.io/cloudservices/celery-exporter:latest
+$ docker build . -tag quay.io/cloudservices/celery-exporter-container:latest
 ```

--- a/deployment/scripts/build_deploy.sh
+++ b/deployment/scripts/build_deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE_NAME="quay.io/cloudservices/celery-exporter"
+IMAGE_NAME="quay.io/cloudservices/celery-exporter-container"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 DOCKER_CONF="${PWD}/.docker"
 

--- a/deployment/scripts/pr_check.sh
+++ b/deployment/scripts/pr_check.sh
@@ -3,7 +3,7 @@
 # Clowder Config
 export APP_NAME="cloudigrade"  # name of app-sre "application" folder this component lives in
 export COMPONENT_NAME="cloudigrade"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
-export IMAGE="quay.io/cloudiservices/celery-exporter" # the image location on quay
+export IMAGE="quay.io/cloudiservices/celery-exporter-container" # the image location on quay
 export DEPLOY_TIMEOUT="420"  # give components a bit more time to deploy
 
 # Install bonfire repo/initialize


### PR DESCRIPTION
- Updating the quay.io/cloudservices/ repo to celery-exporter-container and updated all related build scripts and documentation accordingly.